### PR TITLE
Adjusting group assignment to create groups with the same average strength

### DIFF
--- a/major-supplemental-rulebook.md
+++ b/major-supplemental-rulebook.md
@@ -272,16 +272,17 @@ All Invited and Qualified Teams are first sorted by [Regional Standing](#Regiona
 
 E.g., With two 16-team RMRs, the EUR regional teams would be assigned as follows: 
 
-|     EUR 1 |     EUR 2 |
-|----------:|----------:|
-| 1  and 32 | 2  and 31 |
-| 3  and 30 | 4  and 29 |
-| 5  and 28 | 6  and 27 |
-| 7  and 26 | 8  and 25 |
-| 10 and 24 | 9  and 23 |
-| 12 and 22 | 11 and 21 |
-| 14 and 20 | 13 and 19 |
-| 16 and 18 | 15 and 17 |
+| EUR 1                | EUR 2                |
+| :------------------- | :------------------- |
+| 1  and 32            | 2  and 31            |
+| 3  and 30            | 4  and 29            |
+| 5  and 28            | 6  and 27            |
+| 7  and 26            | 8  and 25            |
+| 10 and 23            | 9  and 24            |
+| 12 and 21            | 11 and 22            |
+| 14 and 19            | 13 and 20            |
+| 16 and 17            | 15 and 18            |
+| Avg. Strength = 16.5 | Avg. Strength = 16.5 |
 
 ##### Swiss Bracket
 - Teams play against opponents of identical W-L record.


### PR DESCRIPTION
The previous assignment of teams created an average strength of 16.75 for EUR 1 and 16.25 for EUR 2.

Swapping the groups for teams with seed 17-24 results in each group receiving the same average strength, while at the same time correctly pairing the highest and lowest ranked teams (each pairing adds up to 33).