### PR TITLE
In the case of 7 teams qualified per group, use the Double Elimination Bracket

### DIFF
--- a/major-supplemental-rulebook.md
+++ b/major-supplemental-rulebook.md
@@ -209,8 +209,9 @@ The RMR format for a region is determined by the number of slots for that region
 		- The remaining two teams play a best of 3 and the loser is eliminated.
 	
 		7 teams: both 3-0 teams, all three 3-1 teams, and two of the three 3-2 teams.
-		- The three 3-2 teams are first sorted by difficulty score. 
-		- The lower two teams play a best of 3 and the loser is eliminated. 
+		- The three 3-2 teams are first sorted by difficulty score.
+  		- The top two teams play a best of 3 and the loser gets a second chance. 
+		- The remaining two teams play a best of 3 and the loser is eliminated. 
 
 		8 teams: both 3-0, all three 3-1, and all three 3-2 teams.
 

--- a/major-supplemental-rulebook.md
+++ b/major-supplemental-rulebook.md
@@ -199,22 +199,8 @@ The RMR format for a region is determined by the number of slots for that region
 	
 	Best of 3: Decider matches (e.g., matches where a team reaches their third win or third loss).
 	
-	At times, it will be necessary to determine Opening or Elimination Stage invitations among a group of teams with identical records. In that case the following process should be used to separate them:
+	At times, it will be necessary to determine which team(s) qualify for the tournament and which do not among a group of teams with identical records. In this case, the following process should be used to separate them:
 	
-		1 team: one of the two 3-0 teams.
-		- The two 3-0 teams play a best of 3 and the loser is eliminated.
-
-		2 teams: both 3-0 teams.
-		
-		3 teams: both 3-0 teams and one of the three 3-1 teams.
-		- The three 3-1 teams are first sorted by difficulty score. 
-		- The lower two teams play a best of 3 and the loser is eliminated. 
-		- The remaining two teams play a best of 3 and the loser is eliminated.
-
-		4 teams: both 3-0 teams and two of the three 3-1 teams.
-		- The three 3-1 teams are first sorted by difficulty score. 
-		- The lower two teams play a best of 3 and the loser is eliminated. 	
-		
 		5 teams: both 3-0 teams and all three 3-1 teams.
 		
 		6 teams: both 3-0 teams, all three 3-1 teams, and one of the three 3-2 team. 


### PR DESCRIPTION
Since invitations to different stages are distributed using VRS, this rule can now be used to determine the format of tiebreaks based on the number of qualifying teams from a group.

Since the swiss format is used to qualify a minimum of 5 teams in a group, the rules for 1-4 teams have been removed.