### PR TITLE
Add rule to resolve potential rematch scenario in round 3

### DIFF
--- a/major-supplemental-rulebook.md
+++ b/major-supplemental-rulebook.md
@@ -303,7 +303,7 @@ E.g., With two 16-team RMRs, the EUR regional teams would be assigned as follows
 - All elimination and advancement matches are to be best of three.
 - All other matches are to be best of one.
 - Teams are not to play the same opponent twice in the same stage, if possible.
-- Matchups shall be determined by [seed](#seeding). The first round follows the [Initial Matchups](#Initial-Matchups). In round 2 and 3, the highest seeded team faces the lowest seeded team available that does not result in a rematch within the stage. In other rounds, refer to the following table and select the top-most row that does not result in a rematch:
+- Matchups shall be determined by [seed](#seeding). The first round follows the [Initial Matchups](#Initial-Matchups). In round 2 and 3, the highest seeded team faces the lowest seeded team available that does not result in a rematch within the stage. In the case that the final matchup assigned is a rematch, the final two high seed matchup teams swap opponents. In other rounds, refer to the following table and select the top-most row that does not result in a rematch:
 
 | Priority |  |  |  |
 |:--------:|--------:|--------:|--------:|


### PR DESCRIPTION
With the introduction of the new [Initial Swiss Matchups rule](https://github.com/ValveSoftware/counter-strike_rules_and_regs/blob/main/major-supplemental-rulebook.md?plain=1#L324-L335) added for the 2024 Copenhagen Major cycle, a flaw with assigning round 3 matchups was introduced.

There's a 0.6% chance that 1-1 record teams in round 3 will force a rematch, which is not allowed by the [current ruleset](https://github.com/ValveSoftware/counter-strike_rules_and_regs/blob/main/major-supplemental-rulebook.md#swiss-bracket).

### Example Matchups

Here's an example round 3 1-1 matchup pool. First we seed based on the [mid-stage seed calculation rules](https://github.com/ValveSoftware/counter-strike_rules_and_regs/blob/main/major-supplemental-rulebook.md#mid-stage-seed-calculation);

 > After the initial matches, seed is determined (in order) by:
 >
 > 1. Current W-L record in the stage
 > 1. Difficulty Score in the current stage
 > 1. Initial seeding of the current stage

| Team | Difficulty | Seed | Previous Opponents |
|------|------------|------|--------------------|
| 1    | 2          | 1    | 1>9, 16>1          |
| 5    | 2          | 5    | 5>13, 12>5         |
| 7    | 2          | 7    | 7>15, 10>7         |
| 11   | 2          | 11   | 11>3, 6>11         |
| 3    | -2         | 3    | 11>3, 3>14         |
| 9    | -2         | 9    | 1>9, 9>8           |
| 13   | -2         | 13   | 5>13, 13>4         |
| 15   | -2         | 15   | 7>15, 15>2         |

Then we follow the [rule for round 3 matchup assignment](https://github.com/ValveSoftware/counter-strike_rules_and_regs/blob/main/major-supplemental-rulebook.md#swiss-bracket):

 >In round 2 and 3, the highest seeded team faces the lowest seeded team available that does not result in a rematch within the stage.

The matchups are created from highest seed first, picking the lowest seed that doesn't result in a rematch:

- **1** is top seed, so they pair with the bottom seed **15** first
- **5** is next highest seed, but already played **13**, so they pair with the next lowest seed, which is **9**
- **7** is next highest seed, and pair with the lowest seed available, which is **13**
- **11** and **3** remain, **but they already played each other in round 1**.

### Resulting flawed matchups

| Team A | Team B |
|--------|--------|
| 1      | 15     |
| 5      | 9      |
| 7      | 13     |
| **11** | **3**  |

This conflicting matchup is **not** present when using the old seeding rules (1v16, 2v15, etc). There is currently no explanation in the rules how to resolve this scenario.

### Solution

To fix this, the rules should be updated to either:

1. Add a clarification to resolve the scenario where rematch conflicts appear (e.g. swap opponents for the last two matchups when a conflict occurs)
1. Revert the Initial Swiss Matchups rule
1. Seed the teams using the Initial Swiss Matchups rule throughout every round of the Swiss event

I chose the first option in this PR, as to preserve the Initial Swiss Matchups rule. There are other ways to resolve the rematch scenarios with varying factors of "fairness". This is the simplest.

### Background

I wrote a Monte Carlo simulator to simulate every potential event outcome, which is how I found the flaw. The source can be found here: https://github.com/claabs/swiss-buchholz-problem