### PR TITLE
Close the loophole enabling bypassing of VRS invite requirements / non VRS invites. 

### DIFF
--- a/tournament-operation-requirements.md
+++ b/tournament-operation-requirements.md
@@ -106,6 +106,8 @@ c) The Roster has not previously declined an invitation to the same Tournament.
 
 For Open Qualifiers, Tournament Operator can use any criteria that in good faith are reasonable and transparent, and do not specifically target individual Rosters. Acceptable criteria include demographics and region (e.g. \"Female Rosters based in Canada\").
 
+3.5.1 Teams entering into an Open Qualifier must start within the same stage.
+
 
 
 3.6 **Wildcard Invite.** 


### PR DESCRIPTION
Currently within the outlined tournament operation requirements, there is no limitation on the seeding of teams wherein they are able to be seeded into different stages.

For example two relevant events are:
[Glitched Masters](https://glitched.se/en/esports/tournaments/cs2) 
[GD Invasion](https://gdinvasion.com/more-info)

Both events have teams enter at the Open Qualifier level, but these teams are then seeded into separate stages.

Glitched Masters is able to seed the top 8 teams signed up into their event, which in effect enables invitations but without the VRS invite requirements, nor the Tier 2 Event requirements having to be met. Teams can signup with the guarantee knowing they make the Main stage of the event, when n

GD Invasion has announced limited details thus far, but from what has been communicated they are also seeding teams based on VRS, also having indicated these could be Top 12 teams. This effectively enables the invitation of Top 12 teams to a higher rung in the tournament, where they enter a further progressed, smaller section of the tournament. The bracket also suggests unranked teams would be seeded higher into the tournament, in effect granting invites to unranked teams to a later stage in the tournament than other teams.

Neither of these cases appear malicious, however this loophole could enable further gaming of the system.

Currently the only restriction on seeding is VRS priority, but there are no further limitations. This loophole enables the ability to bypass the time requirements for ranked events, the required number of invites for ranked events and the limitation on the top 12 teams too as well as other aspects of the TOR.